### PR TITLE
feat: use Tokenizer class in swift-transformers to use BPE

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "1b680daec66a150d77490f0a13f80d01b0c3650c12316b3e243653cc2baf634c",
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "c8ed701b513cf5177118a175d85fbbbcd707ab41",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-transformers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-transformers",
+      "state" : {
+        "branch" : "0.1.8",
+        "revision" : "fc6543263e4caed9bf6107466d625cfae9357f08"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .iOS(.v16),
         .macOS(.v13),
         .macCatalyst(.v16),
-        .tvOS(.v13),
+        .tvOS(.v16),
         .watchOS(.v9),
         .visionOS(.v1),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -6,11 +6,11 @@ import PackageDescription
 let package = Package(
     name: "swift-zenz-coreml",
     platforms: [
-        .iOS(.v15),
-        .macOS(.v12),
-        .macCatalyst(.v15),
-        .tvOS(.v15),
-        .watchOS(.v8),
+        .iOS(.v16),
+        .macOS(.v13),
+        .macCatalyst(.v16),
+        .tvOS(.v13),
+        .watchOS(.v9),
         .visionOS(.v1),
     ],
     products: [
@@ -19,11 +19,17 @@ let package = Package(
             name: "swift-zenz-coreml",
             targets: ["swift-zenz-coreml"]),
     ],
+    dependencies: [
+        .package(url: "https://github.com/huggingface/swift-transformers", branch: "0.1.8"),
+    ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
             name: "swift-zenz-coreml",
+            dependencies: [
+                .product(name: "Transformers", package: "swift-transformers")
+            ],
             resources: [.process("Resources")]
         ),
         .testTarget(

--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ git clone https://github.com/ensan-hcl/swift-zenz-coreml --recursive
 ## Run
 
 ```bash
-xcodebuild -scheme swift-zenz-coreml -destination "platform=macOS,name=Any Mac" -configuration Release test
+xcodebuild -scheme swift-zenz-coreml -destination "platform=macOS,name=Any Mac" test
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ git clone https://github.com/ensan-hcl/swift-zenz-coreml --recursive
 ## Run
 
 ```bash
-swift test
+xcodebuild -scheme swift-zenz-coreml -destination "platform=macOS,name=Any Mac" -configuration Release test
 ```
 

--- a/Sources/swift-zenz-coreml/swift_zenz_coreml.swift
+++ b/Sources/swift-zenz-coreml/swift_zenz_coreml.swift
@@ -1,51 +1,8 @@
 // The Swift Programming Language
 // https://docs.swift.org/swift-book
 import CoreML
+import Tokenizers
 import Foundation
-
-// Tokenizer 구조체 정의
-// Define the Tokenizer struct
-struct Tokenizer {
-    let vocab: [String: Int]
-    let reverseVocab: [Int: String]
-    let config: [String: Any]
-
-    // 초기화
-    // Initializer
-    init(vocabFile: String, configFile: String) {
-        // 번들에서 파일 URL 가져오기
-        // Get the file URLs from the bundle
-        let vocabURL = Bundle.module.url(forResource: vocabFile, withExtension: "json")!
-        let configURL = Bundle.module.url(forResource: configFile, withExtension: "json")!
-        
-        // 파일 데이터를 가져오기
-        // Get the file data
-        let vocabData = try! Data(contentsOf: vocabURL)
-        let configData = try! Data(contentsOf: configURL)
-        
-        // JSON 디코딩
-        // Decode the JSON
-        self.vocab = try! JSONDecoder().decode([String: Int].self, from: vocabData)
-        self.reverseVocab = Dictionary(uniqueKeysWithValues: vocab.map { ($1, $0) })
-        self.config = try! JSONSerialization.jsonObject(with: configData, options: []) as! [String: Any]
-    }
-    
-    // 텍스트를 토큰화
-    // Encode the text
-    func encode(_ text: String) -> [Int] {
-        // 간단한 토크나이저 구현
-        // Simple tokenizer implementation
-        return text.compactMap { vocab[String($0)] }
-    }
-    
-    // 토큰을 텍스트로 디코딩
-    // Decode the tokens
-    func decode(_ tokens: [Int]) -> String {
-        // 역 vocab 사전 사용
-        // Use the reverse vocab dictionary
-        return tokens.compactMap { reverseVocab[$0] }.joined(separator: " ")
-    }
-}
 
 // CoreML 모델 로드 함수
 // Load the CoreML model
@@ -54,13 +11,24 @@ func loadModel() -> zenz_v1? {
     return try? zenz_v1(configuration: config)
 }
 
+// Load the Tokenizer model
+func loadTokenizer() async -> Tokenizer? {
+    do {
+        return try await AutoTokenizer.from(modelFolder: Bundle.module.resourceURL!)
+    } catch {
+        fatalError(error.localizedDescription)
+    }
+}
+
+
 // 예측 수행 함수
 // Perform prediction
 func predict(text: String, model: zenz_v1, tokenizer: Tokenizer) -> [String] {
     // 텍스트를 토크나이저를 사용하여 인코딩
     // Encode the input text using the tokenizer
-    let inputIDs = tokenizer.encode(text)
-    
+    let inputIDs = tokenizer.encode(text: text)
+    print("inputIDs", text, inputIDs)
+
     // 입력을 위한 MLMultiArray 생성
     // Create MLMultiArray for input
     let inputArray = try? MLMultiArray(shape: [1, 16], dataType: .float32)
@@ -91,29 +59,34 @@ func predict(text: String, model: zenz_v1, tokenizer: Tokenizer) -> [String] {
     // logits에서 예측된 토큰 ID 추출
     // Extract predicted token IDs from logits
     var predictedTokenIDs = [[Int]]()
-    for i in 0..<logits.shape[1].intValue {
-        var logitValues = [Float]()
-        for j in 0..<logits.shape[2].intValue {
-            logitValues.append(logits[[0, i, j] as [NSNumber]].floatValue)
+    for batchID in 0..<logits.shape[0].intValue {
+        predictedTokenIDs.append([])
+        for i in 0..<logits.shape[1].intValue {
+            var logitValues = [Float]()
+            // get argMax
+            let maxId = (0..<6000).max {
+                logits[[batchID, i, $0] as [NSNumber]].floatValue > logits[[0, i, $1] as [NSNumber]].floatValue
+            } ?? 0
+            predictedTokenIDs[batchID].append(maxId)
         }
-        predictedTokenIDs.append(logitValues.indices.sorted(by: { logitValues[$0] > logitValues[$1] }))
     }
-    
+
     // 예측된 토큰 ID를 다시 텍스트로 디코딩
     // Decode the predicted token IDs back to text
-    let predictedTexts = predictedTokenIDs.map { tokenizer.decode(Array($0.prefix(5))) }
+    print(predictedTokenIDs)
+    let predictedTexts = predictedTokenIDs.map { tokenizer.decode(tokens: $0) }
     
     // 결과 출력
     // Print the result
     return predictedTexts
 }
 
-func main() {
-    let model = loadModel()
-    
-    guard let model else { fatalError("model not found") }
-    let tokenizer = Tokenizer(vocabFile: "vocab", configFile: "tokenizer_config")
-    let predictedSentence = predict(text: "\u{EE00}ニホンゴ\u{EE01}", model: model, tokenizer: tokenizer)
+func main() async {
 
+    let model = loadModel()
+    guard let model else { fatalError("model not found") }
+    let tokenizer = await loadTokenizer()
+    guard let tokenizer else { fatalError("tokenizer not found") }
+    let predictedSentence = predict(text: "\u{EE00}ニホンゴ\u{EE01}", model: model, tokenizer: tokenizer)
     print(predictedSentence)
 }

--- a/Sources/swift-zenz-coreml/swift_zenz_coreml.swift
+++ b/Sources/swift-zenz-coreml/swift_zenz_coreml.swift
@@ -13,8 +13,12 @@ func loadModel() -> zenz_v1? {
 
 // Load the Tokenizer model
 func loadTokenizer() async -> Tokenizer? {
+    guard let modelFolder = Bundle.module.resourceURL else {
+        print("Model Folder was not found")
+        return nil
+    }
     do {
-        return try await AutoTokenizer.from(modelFolder: Bundle.module.resourceURL!)
+        return try await AutoTokenizer.from(modelFolder: modelFolder)
     } catch {
         fatalError(error.localizedDescription)
     }
@@ -67,7 +71,7 @@ func predict(text: String, model: zenz_v1, tokenizer: Tokenizer) -> [String] {
             var logitValues = [Float]()
             // get argMax
             let maxId = (0..<6000).max {
-                logits[[batchID, i, $0] as [NSNumber]].floatValue > logits[[0, i, $1] as [NSNumber]].floatValue
+                logits[[batchID, i, $0] as [NSNumber]].floatValue < logits[[0, i, $1] as [NSNumber]].floatValue
             } ?? 0
             predictedTokenIDs[batchID].append(maxId)
         }

--- a/Sources/swift-zenz-coreml/swift_zenz_coreml.swift
+++ b/Sources/swift-zenz-coreml/swift_zenz_coreml.swift
@@ -15,8 +15,8 @@ struct Tokenizer {
     init(vocabFile: String, configFile: String) {
         // 번들에서 파일 URL 가져오기
         // Get the file URLs from the bundle
-        let vocabURL = Bundle.main.url(forResource: vocabFile, withExtension: "json")!
-        let configURL = Bundle.main.url(forResource: configFile, withExtension: "json")!
+        let vocabURL = Bundle.module.url(forResource: vocabFile, withExtension: "json")!
+        let configURL = Bundle.module.url(forResource: configFile, withExtension: "json")!
         
         // 파일 데이터를 가져오기
         // Get the file data
@@ -35,7 +35,7 @@ struct Tokenizer {
     func encode(_ text: String) -> [Int] {
         // 간단한 토크나이저 구현
         // Simple tokenizer implementation
-        return text.split(separator: " ").compactMap { vocab[String($0)] }
+        return text.compactMap { vocab[String($0)] }
     }
     
     // 토큰을 텍스트로 디코딩
@@ -113,7 +113,7 @@ func main() {
     
     guard let model else { fatalError("model not found") }
     let tokenizer = Tokenizer(vocabFile: "vocab", configFile: "tokenizer_config")
-    let predictedSentence = predict(text: "Example sentence", model: model, tokenizer: tokenizer)
-    
+    let predictedSentence = predict(text: "\u{EE00}ニホンゴ\u{EE01}", model: model, tokenizer: tokenizer)
+
     print(predictedSentence)
 }

--- a/Tests/swift-zenz-coremlTests/swift_zenz_coremlTests.swift
+++ b/Tests/swift-zenz-coremlTests/swift_zenz_coremlTests.swift
@@ -5,13 +5,13 @@ final class swift_zenz_coremlTests: XCTestCase {
 
     
 
-    func testExample() throws {
+    func testExample() async throws {
         // XCTest Documentation
         // https://developer.apple.com/documentation/xctest
 
         // Defining Test Cases and Test Methods
         // https://developer.apple.com/documentation/xctest/defining_test_cases_and_test_methods
 
-        main()
+        await main()
     }
 }


### PR DESCRIPTION
* The `Tokenizer` class in [swift-transformers](https://github.com/huggingface/swift-transformers) works greatly with GPT-2 tokenizers. I added a dependency to it and achieved correct BPE tokenization in Swift!
* I also updated the logic for decoding to get the correct behavior (output now has exactly 16 tokens as expected!
* I am observing `nan` output in logits so the model is not predicting as expected. This should be fixed in another PR.
* This PR requires https://github.com/Skyline-23/zenz-CoreML/pull/1 to be merged.