### PR TITLE
feat: implement simple greedy decoding, and now it is completely usable base of zenzai!!

### DIFF
--- a/Sources/swift-zenz-coreml/swift_zenz_coreml.swift
+++ b/Sources/swift-zenz-coreml/swift_zenz_coreml.swift
@@ -171,6 +171,8 @@ func main() async {
     let tokenizer = await loadTokenizer()
     guard let tokenizer else { fatalError("tokenizer not found") }
     // ニホンゴ（Japanese in Katakana Form）→日本語（Japanese in Kanji form）
+    let start = Date()
     let predictedSentence = greedyPredict(text: "\u{EE00}ニホンゴ\u{EE01}", model: model, tokenizer: tokenizer)
     print(predictedSentence)
+    print("time:", Date().timeIntervalSince(start))
 }

--- a/Sources/swift-zenz-coreml/swift_zenz_coreml.swift
+++ b/Sources/swift-zenz-coreml/swift_zenz_coreml.swift
@@ -170,9 +170,18 @@ func main() async {
     guard let model else { fatalError("model not found") }
     let tokenizer = await loadTokenizer()
     guard let tokenizer else { fatalError("tokenizer not found") }
-    // ニホンゴ（Japanese in Katakana Form）→日本語（Japanese in Kanji form）
-    let start = Date()
-    let predictedSentence = greedyPredict(text: "\u{EE00}ニホンゴ\u{EE01}", model: model, tokenizer: tokenizer)
-    print(predictedSentence)
-    print("time:", Date().timeIntervalSince(start))
+    do {
+        // ニホンゴ（Japanese in Katakana Form）→日本語（Japanese in Kanji form）
+        let start = Date()
+        let predictedSentence = greedyPredict(text: "\u{EE00}ニホンゴ\u{EE01}", model: model, tokenizer: tokenizer)
+        print(predictedSentence)
+        print("time:", Date().timeIntervalSince(start))
+    }
+    do {
+        // カンコクゴヲベンキョウスル（'Study Korean' in Katakana Form）→韓国語を勉強する（'Study Korean' in Kanji form）
+        let start = Date()
+        let predictedSentence = greedyPredict(text: "\u{EE00}カンコクゴヲベンキョウスル\u{EE01}", model: model, tokenizer: tokenizer)
+        print(predictedSentence)
+        print("time:", Date().timeIntervalSince(start))
+    }
 }

--- a/Sources/swift-zenz-coreml/swift_zenz_coreml.swift
+++ b/Sources/swift-zenz-coreml/swift_zenz_coreml.swift
@@ -170,6 +170,7 @@ func main() async {
     guard let model else { fatalError("model not found") }
     let tokenizer = await loadTokenizer()
     guard let tokenizer else { fatalError("tokenizer not found") }
+    // ニホンゴ（Japanese in Katakana Form）→日本語（Japanese in Kanji form）
     let predictedSentence = greedyPredict(text: "\u{EE00}ニホンゴ\u{EE01}", model: model, tokenizer: tokenizer)
     print(predictedSentence)
 }

--- a/Sources/swift-zenz-coreml/swift_zenz_coreml.swift
+++ b/Sources/swift-zenz-coreml/swift_zenz_coreml.swift
@@ -20,7 +20,6 @@ func loadTokenizer() async -> Tokenizer? {
     }
 }
 
-
 // 예측 수행 함수
 // Perform prediction
 func predict(text: String, model: zenz_v1, tokenizer: Tokenizer) -> [String] {
@@ -35,27 +34,27 @@ func predict(text: String, model: zenz_v1, tokenizer: Tokenizer) -> [String] {
     for (index, token) in inputIDs.enumerated() {
         inputArray?[index] = NSNumber(value: token)
     }
-    
+
     // Attention mask 생성
     // Create attention mask
     let attentionMask = try? MLMultiArray(shape: [1, 16], dataType: .float32)
     for i in 0..<inputIDs.count {
         attentionMask?[i] = 1
     }
-    
+
     guard let inputArray, let attentionMask else { return [] }
     // 모델 입력 생성
     // Create model input
     let input = zenz_v1Input(input_ids: inputArray, attention_mask: attentionMask)
-    
+
     // 예측 수행
     // Perform prediction
     let output = try? model.prediction(input: input)
-    
+
     // 출력 logits 디코딩
     // Decode the output logits
     let logits = output?.linear_0
-    
+
     guard let logits else { return [] }
 
     // logits에서 예측된 토큰 ID 추출
@@ -67,7 +66,7 @@ func predict(text: String, model: zenz_v1, tokenizer: Tokenizer) -> [String] {
             var logitValues = [Float]()
             // get argMax
             let maxId = (0..<6000).max {
-                logits[[batchID, i, $0] as [NSNumber]].floatValue > logits[[0, i, $1] as [NSNumber]].floatValue
+                logits[[batchID, i, $0] as [NSNumber]].floatValue < logits[[0, i, $1] as [NSNumber]].floatValue
             } ?? 0
             predictedTokenIDs[batchID].append(maxId)
         }
@@ -77,18 +76,96 @@ func predict(text: String, model: zenz_v1, tokenizer: Tokenizer) -> [String] {
     // Decode the predicted token IDs back to text
     print(predictedTokenIDs)
     let predictedTexts = predictedTokenIDs.map { tokenizer.decode(tokens: $0) }
-    
+
     // 결과 출력
     // Print the result
     return predictedTexts
 }
 
-func main() async {
+// Greedy search를 사용하여 예측 수행
+// Perform prediction using Greedy search
+func greedyPredict(text: String, model: zenz_v1, tokenizer: Tokenizer) -> String {
+    // 텍스트를 토크나이저를 사용하여 인코딩
+    // Encode the input text using the tokenizer
+    var inputIDs = tokenizer.encode(text: text)
+    print("inputIDs", text, inputIDs)
 
+    // 최대 시퀀스 길이 설정
+    // Set the maximum sequence length
+    let maxSeqLength = 128
+    let batchSize = 1
+
+    // 예측된 토큰 ID를 저장할 배열
+    // Array to store predicted token IDs
+    var predictedTokenIDs = inputIDs
+
+    while true {
+        // 입력을 위한 MLMultiArray 생성
+        // Create MLMultiArray for input
+        let inputArray = try? MLMultiArray(shape: [NSNumber(value: batchSize), NSNumber(value: predictedTokenIDs.count)], dataType: .int32)
+        for (index, token) in predictedTokenIDs.enumerated() {
+            inputArray?[index] = NSNumber(value: token)
+        }
+
+        // Attention mask 생성
+        // Create attention mask
+        let attentionMask = try? MLMultiArray(shape: [NSNumber(value: batchSize), NSNumber(value: predictedTokenIDs.count)], dataType: .int32)
+        for i in 0..<predictedTokenIDs.count {
+            attentionMask?[i] = 1
+        }
+
+        guard let inputArray, let attentionMask else { return "" }
+
+        // 모델 입력 생성
+        // Create model input
+        let input = zenz_v1Input(input_ids: inputArray, attention_mask: attentionMask)
+
+        // 예측 수행
+        // Perform prediction
+        guard let output = try? model.prediction(input: input) else { return "" }
+
+        // 출력 logits 디코딩
+        // Decode the output logits
+        let logits = output.linear_0
+
+        // logits에서 예측된 토큰 ID 추출
+        // Extract predicted token ID from logits
+        let nextTokenID = (0..<logits.shape[2].intValue).max {
+            logits[[0, predictedTokenIDs.count - 1, $0] as [NSNumber]].floatValue <
+                logits[[0, predictedTokenIDs.count - 1, $1] as [NSNumber]].floatValue
+        } ?? 0
+
+        // 종료 토큰 체크 (예: <EOS> 토큰 ID)
+        // Check for end token (e.g., <EOS> token ID)
+        if nextTokenID == 3 {
+            break
+        }
+
+        // 예측된 토큰 ID를 추가
+        // Add the predicted token ID
+        predictedTokenIDs.append(nextTokenID)
+
+        // 최대 시퀀스 길이에 도달하면 종료
+        // Exit if the maximum sequence length is reached
+        if predictedTokenIDs.count >= maxSeqLength {
+            break
+        }
+    }
+
+    // 예측된 토큰 ID를 다시 텍스트로 디코딩
+    // Decode the predicted token IDs back to text
+    let predictedText = tokenizer.decode(tokens: predictedTokenIDs)
+
+    // 결과 출력
+    // Print the result
+    return predictedText
+}
+
+func main() async {
     let model = loadModel()
     guard let model else { fatalError("model not found") }
     let tokenizer = await loadTokenizer()
     guard let tokenizer else { fatalError("tokenizer not found") }
-    let predictedSentence = predict(text: "\u{EE00}ニホンゴ\u{EE01}", model: model, tokenizer: tokenizer)
+    let predictedSentence = greedyPredict(text: "\u{EE00}ニホンゴ\u{EE01}", model: model, tokenizer: tokenizer)
     print(predictedSentence)
 }


### PR DESCRIPTION
* I implemented simple greedy decoding
  Sample output as follows:
  ```
  inputIDs ニホンゴ [172, 120, 202, 444, 677, 259, 796, 172, 120, 203]
  ニホンゴ日本語
  ```

* This PR requires https://github.com/Skyline-23/zenz-CoreML/pull/2 to be merged